### PR TITLE
[PMM-1828] Fix generation of unitfiles and init.d scripts

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -162,6 +162,8 @@ func (s *systemd) Status() error {
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path|cmdEscape}}
+After=network.target
+After=syslog.target
 
 [Service]
 StartLimitInterval=5

--- a/service_sysv_linux.go
+++ b/service_sysv_linux.go
@@ -177,7 +177,8 @@ const sysvScript = `#!/bin/sh
 
 cmd='{{.Path}}{{range .Arguments}} {{.}}{{end}}'
 
-name=$(basename $0)
+real_path=$(readlink -f $0)
+name=$(basename $real_path)
 pid_file="/var/run/$name.pid"
 log_file="/var/log/$name.log"
 


### PR DESCRIPTION
For systemd it is necessary to set After parameter
For init script it is necessary to get absolute path to init script
as on upstart process is running by link from rc.d