### PR TITLE
PMM-1486: Properly escape cmd in init script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go_import_path: github.com/percona/kardianos-service
 sudo: required
 
 go:
-  - 1.6.x
   - 1.7.x
   - 1.8.x
   - 1.9.x

--- a/linux_test/Makefile
+++ b/linux_test/Makefile
@@ -2,7 +2,7 @@
 all: sysv systemd upstart clean
 
 test:
-	@go test -c ..
+	@go test -o service.test -c ..
 
 clean:
 	-rm service.test

--- a/service_darwin.go
+++ b/service_darwin.go
@@ -188,8 +188,8 @@ func (s *darwinLaunchdService) Restart() error {
 	return s.Start()
 }
 func (s *darwinLaunchdService) Status() error {
-        // Not implemented
-        return nil
+	// Not implemented
+	return nil
 }
 
 func (s *darwinLaunchdService) Run() error {

--- a/service_linux.go
+++ b/service_linux.go
@@ -67,7 +67,8 @@ func isInteractive() (bool, error) {
 
 var tf = map[string]interface{}{
 	"cmd": func(s string) string {
-		return `"` + strings.Replace(s, `"`, `\"`, -1) + `"`
+		// Put command in single quotes, otherwise special characters like dollar ($) sign will be interpreted.
+		return `'` + strings.Replace(s, `'`, `'"'"'`, -1) + `'`
 	},
 	"cmdEscape": func(s string) string {
 		return strings.Replace(s, " ", `\x20`, -1)

--- a/service_linux_test.go
+++ b/service_linux_test.go
@@ -1,0 +1,24 @@
+package service
+
+import "testing"
+
+func TestTemplateFunctionCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			"bad'p$ass",
+			"bad'p$ass",
+			`'bad'"'"'p$ass'`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tf["cmd"].(func(string) string)(tt.arg); got != tt.want {
+				t.Errorf("tf[cmd](%s) = %v, want %v", tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/service_windows.go
+++ b/service_windows.go
@@ -328,8 +328,8 @@ func (ws *windowsService) Restart() error {
 }
 
 func (ws *windowsService) Status() error {
-        // Not implemented
-        return nil
+	// Not implemented
+	return nil
 }
 
 func (ws *windowsService) stopWait(s *mgr.Service) error {


### PR DESCRIPTION
Within double quotes `"` a dollar sign `$` is interpreted as shell variable. Use single quotes instead.